### PR TITLE
Handling async nature of plotly

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -18,7 +18,7 @@ export interface IPlotlyChartProps {
  *               onClick={({points, event}) => console.log(points, event)}>
  */
 declare class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
-    protected plotlyElement: plotly.PlotlyHTMLElement | null;
+    container: plotly.PlotlyHTMLElement | null;
     attachListeners(): void;
     resize: () => void;
     draw: (props: IPlotlyChartProps) => Promise<void>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,29 +1,15 @@
 /// <reference types="react" />
+import * as plotly from 'plotly.js';
 import * as React from 'react';
 export interface IPlotlyChartProps {
-    config?: any;
-    data: any[];
-    layout?: any;
-    onClick?: (data: {
-        points: any;
-        event: any;
-    }) => any;
-    onBeforeHover?: (data: {
-        points: any;
-        event: any;
-    }) => any;
-    onHover?: (data: {
-        points: any;
-        event: any;
-    }) => any;
-    onUnHover?: (data: {
-        points: any;
-        event: any;
-    }) => any;
-    onSelected?: (data: {
-        points: any;
-        event: any;
-    }) => any;
+    config?: plotly.Config;
+    data: Partial<plotly.ScatterData>[];
+    layout?: plotly.Layout;
+    onClick?: (event: plotly.PlotMouseEvent) => void;
+    onBeforeHover?: (event: plotly.PlotMouseEvent) => void;
+    onHover?: (event: plotly.PlotMouseEvent) => void;
+    onUnHover?: (event: plotly.PlotMouseEvent) => void;
+    onSelected?: (event: plotly.PlotSelectionEvent) => void;
 }
 /***
  * Usage:
@@ -32,10 +18,10 @@ export interface IPlotlyChartProps {
  *               onClick={({points, event}) => console.log(points, event)}>
  */
 declare class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
-    container: any;
+    protected plotlyElement: plotly.PlotlyHTMLElement | null;
     attachListeners(): void;
     resize: () => void;
-    draw: (props: IPlotlyChartProps) => void;
+    draw: (props: IPlotlyChartProps) => Promise<void>;
     componentWillReceiveProps(nextProps: IPlotlyChartProps): void;
     componentDidMount(): void;
     componentWillUnmount(): void;

--- a/dist/index.js
+++ b/dist/index.js
@@ -74,10 +74,10 @@ var PlotlyChart = /** @class */ (function (_super) {
     __extends(PlotlyChart, _super);
     function PlotlyChart() {
         var _this = _super !== null && _super.apply(this, arguments) || this;
-        _this.plotlyElement = null;
+        _this.container = null;
         _this.resize = function () {
-            if (_this.plotlyElement) {
-                plotly.Plots.resize(_this.plotlyElement);
+            if (_this.container) {
+                plotly.Plots.resize(_this.container);
             }
         };
         _this.draw = function (props) { return __awaiter(_this, void 0, void 0, function () {
@@ -86,13 +86,13 @@ var PlotlyChart = /** @class */ (function (_super) {
                 switch (_b.label) {
                     case 0:
                         data = props.data, layout = props.layout, config = props.config;
-                        if (!this.plotlyElement) return [3 /*break*/, 2];
+                        if (!this.container) return [3 /*break*/, 2];
                         // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
                         _a = this;
-                        return [4 /*yield*/, plotly.react(this.plotlyElement, data, Object.assign({}, layout), config)];
+                        return [4 /*yield*/, plotly.react(this.container, data, Object.assign({}, layout), config)];
                     case 1:
                         // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
-                        _a.plotlyElement = _b.sent();
+                        _a.container = _b.sent();
                         _b.label = 2;
                     case 2: return [2 /*return*/];
                 }
@@ -102,16 +102,16 @@ var PlotlyChart = /** @class */ (function (_super) {
     }
     PlotlyChart.prototype.attachListeners = function () {
         if (this.props.onClick) {
-            this.plotlyElement.on('plotly_click', this.props.onClick);
+            this.container.on('plotly_click', this.props.onClick);
         }
         if (this.props.onHover) {
-            this.plotlyElement.on('plotly_hover', this.props.onHover);
+            this.container.on('plotly_hover', this.props.onHover);
         }
         if (this.props.onUnHover) {
-            this.plotlyElement.on('plotly_unhover', this.props.onUnHover);
+            this.container.on('plotly_unhover', this.props.onUnHover);
         }
         if (this.props.onSelected) {
-            this.plotlyElement.on('plotly_selected', this.props.onSelected);
+            this.container.on('plotly_selected', this.props.onSelected);
         }
         window.addEventListener('resize', this.resize);
     };
@@ -122,8 +122,8 @@ var PlotlyChart = /** @class */ (function (_super) {
         this.draw(this.props);
     };
     PlotlyChart.prototype.componentWillUnmount = function () {
-        if (this.plotlyElement) {
-            plotly.purge(this.plotlyElement);
+        if (this.container) {
+            plotly.purge(this.container);
         }
         window.removeEventListener('resize', this.resize);
     };
@@ -135,11 +135,11 @@ var PlotlyChart = /** @class */ (function (_super) {
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
-                            if (!(node && !this.plotlyElement)) return [3 /*break*/, 2];
+                            if (!(node && !this.container)) return [3 /*break*/, 2];
                             _a = this;
                             return [4 /*yield*/, plotly.newPlot(node, data, Object.assign({}, layout), config)];
                         case 1:
-                            _a.plotlyElement = _b.sent();
+                            _a.container = _b.sent();
                             _b.label = 2;
                         case 2: return [2 /*return*/];
                     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,6 +17,41 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
     }
     return t;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -27,9 +62,8 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+var plotly = require("plotly.js");
 var React = require("react");
-var plotlyInstance = require("plotly.js/dist/plotly.js");
-var lodash_1 = require("lodash");
 /***
  * Usage:
  *  <PlotlyChart data={toJS(this.model_data)}
@@ -40,33 +74,44 @@ var PlotlyChart = /** @class */ (function (_super) {
     __extends(PlotlyChart, _super);
     function PlotlyChart() {
         var _this = _super !== null && _super.apply(this, arguments) || this;
-        _this.container = null;
+        _this.plotlyElement = null;
         _this.resize = function () {
-            plotlyInstance.Plots.resize(_this.container);
+            if (_this.plotlyElement) {
+                plotly.Plots.resize(_this.plotlyElement);
+            }
         };
-        _this.draw = function (props) {
-            var data = props.data, layout = props.layout, config = props.config;
-            // We clone the layout as plotly mutates it.
-            plotlyInstance.newPlot(_this.container, data, lodash_1.cloneDeep(layout), config);
-            _this.attachListeners();
-        };
+        _this.draw = function (props) { return __awaiter(_this, void 0, void 0, function () {
+            var data, layout, config, _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        data = props.data, layout = props.layout, config = props.config;
+                        if (!this.plotlyElement) return [3 /*break*/, 2];
+                        // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
+                        _a = this;
+                        return [4 /*yield*/, plotly.react(this.plotlyElement, data, Object.assign({}, layout), config)];
+                    case 1:
+                        // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
+                        _a.plotlyElement = _b.sent();
+                        _b.label = 2;
+                    case 2: return [2 /*return*/];
+                }
+            });
+        }); };
         return _this;
     }
     PlotlyChart.prototype.attachListeners = function () {
         if (this.props.onClick) {
-            this.container.on('plotly_click', this.props.onClick);
-        }
-        if (this.props.onBeforeHover) {
-            this.container.on('plotly_beforehover', this.props.onBeforeHover);
+            this.plotlyElement.on('plotly_click', this.props.onClick);
         }
         if (this.props.onHover) {
-            this.container.on('plotly_hover', this.props.onHover);
+            this.plotlyElement.on('plotly_hover', this.props.onHover);
         }
         if (this.props.onUnHover) {
-            this.container.on('plotly_unhover', this.props.onUnHover);
+            this.plotlyElement.on('plotly_unhover', this.props.onUnHover);
         }
         if (this.props.onSelected) {
-            this.container.on('plotly_selected', this.props.onSelected);
+            this.plotlyElement.on('plotly_selected', this.props.onSelected);
         }
         window.addEventListener('resize', this.resize);
     };
@@ -77,15 +122,30 @@ var PlotlyChart = /** @class */ (function (_super) {
         this.draw(this.props);
     };
     PlotlyChart.prototype.componentWillUnmount = function () {
-        plotlyInstance.purge(this.container);
+        if (this.plotlyElement) {
+            plotly.purge(this.plotlyElement);
+        }
         window.removeEventListener('resize', this.resize);
     };
     PlotlyChart.prototype.render = function () {
         var _this = this;
-        var _a = this.props, data = _a.data, layout = _a.layout, config = _a.config, onClick = _a.onClick, onBeforeHover = _a.onBeforeHover, onHover = _a.onHover, onSelected = _a.onSelected, onUnHover = _a.onUnHover, other = __rest(_a, ["data", "layout", "config", "onClick", "onBeforeHover", "onHover", "onSelected", "onUnHover"]);
-        return React.createElement("div", __assign({}, other, { ref: function (node) { return _this.container = node; } }));
+        var _a = this.props, data = _a.data, layout = _a.layout, config = _a.config, onClick = _a.onClick, onHover = _a.onHover, onSelected = _a.onSelected, onUnHover = _a.onUnHover, other = __rest(_a, ["data", "layout", "config", "onClick", "onHover", "onSelected", "onUnHover"]);
+        return (React.createElement("div", __assign({}, other, { ref: function (node) { return __awaiter(_this, void 0, void 0, function () {
+                var _a;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            if (!(node && !this.plotlyElement)) return [3 /*break*/, 2];
+                            _a = this;
+                            return [4 /*yield*/, plotly.newPlot(node, data, Object.assign({}, layout), config)];
+                        case 1:
+                            _a.plotlyElement = _b.sent();
+                            _b.label = 2;
+                        case 2: return [2 /*return*/];
+                    }
+                });
+            }); } })));
     };
     return PlotlyChart;
 }(React.Component));
-;
 exports.default = PlotlyChart;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export interface IPlotlyChartProps {
   config?: plotly.Config;
-  data: Partial<plotly.ScatterData>[]
+  data: Partial<plotly.ScatterData>[];
   layout?: plotly.Layout;
   onClick?: (event: plotly.PlotMouseEvent) => void;
   onBeforeHover?: (event: plotly.PlotMouseEvent) => void;
@@ -48,6 +48,7 @@ class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
     if (this.container) {
       // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
       this.container = await plotly.react(this.container, data, Object.assign({}, layout), config);
+      this.attachListeners();
     }
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,15 @@
+import * as plotly from 'plotly.js';
 import * as React from 'react';
-import * as plotlyInstance from 'plotly.js/dist/plotly.js';
-import {cloneDeep} from 'lodash';
 
 export interface IPlotlyChartProps {
-    config?: any;
-    data: any[];
-    layout?: any;
-    onClick?: (data: { points: any, event: any }) => any;
-    onBeforeHover?: (data: { points: any, event: any }) => any;
-    onHover?: (data: { points: any, event: any }) => any;
-    onUnHover?: (data: { points: any, event: any }) => any;
-    onSelected?: (data: { points: any, event: any }) => any;
+  config?: plotly.Config;
+  data: Partial<plotly.ScatterData>[]
+  layout?: plotly.Layout;
+  onClick?: (event: plotly.PlotMouseEvent) => void;
+  onBeforeHover?: (event: plotly.PlotMouseEvent) => void;
+  onHover?: (event: plotly.PlotMouseEvent) => void;
+  onUnHover?: (event: plotly.PlotMouseEvent) => void;
+  onSelected?: (event: plotly.PlotSelectionEvent) => void;
 }
 
 /***
@@ -20,57 +19,66 @@ export interface IPlotlyChartProps {
  *               onClick={({points, event}) => console.log(points, event)}>
  */
 class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
+  protected plotlyElement: plotly.PlotlyHTMLElement | null = null;
 
-    container: any = null;
-
-    attachListeners() {
-        if (this.props.onClick) {
-            this.container.on('plotly_click', this.props.onClick);
-        }
-        if (this.props.onBeforeHover) {
-            this.container.on('plotly_beforehover', this.props.onBeforeHover);
-        }
-        if (this.props.onHover) {
-            this.container.on('plotly_hover', this.props.onHover);
-        }
-        if (this.props.onUnHover) {
-            this.container.on('plotly_unhover', this.props.onUnHover);
-        }
-        if (this.props.onSelected) {
-            this.container.on('plotly_selected', this.props.onSelected);
-        }
-        window.addEventListener('resize', this.resize);
+  public attachListeners() {
+    if (this.props.onClick) {
+      this.plotlyElement!.on('plotly_click', this.props.onClick);
     }
-
-    resize = () => {
-        plotlyInstance.Plots.resize(this.container);
+    if (this.props.onHover) {
+      this.plotlyElement!.on('plotly_hover', this.props.onHover);
     }
-
-    draw = (props: IPlotlyChartProps) => {
-        const {data, layout, config} = props;
-        // We clone the layout as plotly mutates it.
-        plotlyInstance.newPlot(this.container, data, cloneDeep(layout), config);
-        this.attachListeners();
+    if (this.props.onUnHover) {
+      this.plotlyElement!.on('plotly_unhover', this.props.onUnHover);
     }
-
-
-    componentWillReceiveProps(nextProps: IPlotlyChartProps) {
-        this.draw(nextProps);
+    if (this.props.onSelected) {
+      this.plotlyElement!.on('plotly_selected', this.props.onSelected);
     }
+    window.addEventListener('resize', this.resize);
+  }
 
-    componentDidMount() {
-        this.draw(this.props);
+  public resize = () => {
+    if (this.plotlyElement) {
+      plotly.Plots.resize(this.plotlyElement);
     }
+  };
 
-    componentWillUnmount() {
-        plotlyInstance.purge(this.container);
-        window.removeEventListener('resize', this.resize);
+  public draw = async (props: IPlotlyChartProps) => {
+    const { data, layout, config } = props;
+    if (this.plotlyElement) {
+      // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
+      this.plotlyElement = await plotly.react(this.plotlyElement, data, Object.assign({}, layout), config);
     }
+  };
 
-    render() {
-        const {data, layout, config, onClick, onBeforeHover, onHover, onSelected, onUnHover, ...other} = this.props;
-        return <div {...other} ref={(node) => this.container = node}/>;
+  public componentWillReceiveProps(nextProps: IPlotlyChartProps) {
+    this.draw(nextProps);
+  }
+
+  public componentDidMount() {
+    this.draw(this.props);
+  }
+
+  public componentWillUnmount() {
+    if (this.plotlyElement) {
+      plotly.purge(this.plotlyElement);
     }
-};
+    window.removeEventListener('resize', this.resize);
+  }
+
+  public render() {
+    const { data, layout, config, onClick, onHover, onSelected, onUnHover, ...other } = this.props;
+    return (
+      <div
+        {...other}
+        ref={async node => {
+          if (node && !this.plotlyElement) {
+            this.plotlyElement = await plotly.newPlot(node, data as any, Object.assign({}, layout), config);
+          }
+        }}
+      />
+    );
+  }
+}
 
 export default PlotlyChart;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,35 +19,35 @@ export interface IPlotlyChartProps {
  *               onClick={({points, event}) => console.log(points, event)}>
  */
 class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
-  protected plotlyElement: plotly.PlotlyHTMLElement | null = null;
+  public container: plotly.PlotlyHTMLElement | null = null;
 
   public attachListeners() {
     if (this.props.onClick) {
-      this.plotlyElement!.on('plotly_click', this.props.onClick);
+      this.container!.on('plotly_click', this.props.onClick);
     }
     if (this.props.onHover) {
-      this.plotlyElement!.on('plotly_hover', this.props.onHover);
+      this.container!.on('plotly_hover', this.props.onHover);
     }
     if (this.props.onUnHover) {
-      this.plotlyElement!.on('plotly_unhover', this.props.onUnHover);
+      this.container!.on('plotly_unhover', this.props.onUnHover);
     }
     if (this.props.onSelected) {
-      this.plotlyElement!.on('plotly_selected', this.props.onSelected);
+      this.container!.on('plotly_selected', this.props.onSelected);
     }
     window.addEventListener('resize', this.resize);
   }
 
   public resize = () => {
-    if (this.plotlyElement) {
-      plotly.Plots.resize(this.plotlyElement);
+    if (this.container) {
+      plotly.Plots.resize(this.container);
     }
   };
 
   public draw = async (props: IPlotlyChartProps) => {
     const { data, layout, config } = props;
-    if (this.plotlyElement) {
+    if (this.container) {
       // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
-      this.plotlyElement = await plotly.react(this.plotlyElement, data, Object.assign({}, layout), config);
+      this.container = await plotly.react(this.container, data, Object.assign({}, layout), config);
     }
   };
 
@@ -60,8 +60,8 @@ class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
   }
 
   public componentWillUnmount() {
-    if (this.plotlyElement) {
-      plotly.purge(this.plotlyElement);
+    if (this.container) {
+      plotly.purge(this.container);
     }
     window.removeEventListener('resize', this.resize);
   }
@@ -72,8 +72,8 @@ class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
       <div
         {...other}
         ref={async node => {
-          if (node && !this.plotlyElement) {
-            this.plotlyElement = await plotly.newPlot(node, data as any, Object.assign({}, layout), config);
+          if (node && !this.container) {
+            this.container = await plotly.newPlot(node, data as any, Object.assign({}, layout), config);
           }
         }}
       />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,17 +3,17 @@
     "declaration": true,
     "outDir": "dist",
     "strictNullChecks": true,
+    "lib": [
+      "es2015",
+      "es2016",
+      "es2017",
+      "dom"
+    ],
     "module": "commonjs",
     "target": "es5",
     "jsx": "react"
   },
   "include": [
     "./src/"
-  ],
-  "lib": [
-    "es2015",
-    "es2016",
-    "es2017",
-    "dom"
   ]
 }


### PR DESCRIPTION
- When given data that updates frequently, I observed multiple webgl contexts being created. By taking advantage of the async nature of the newPlot and react functions from plotly, this should no longer happen! :D
- Removed 'plotly_beforehover' since it is not a event exposed by plotly.
- Added plotly types to better facilitate communication between developer using react-plotlyjs-ts and underlying plotly API.