### PR TITLE
Do not attach listeners after each draw

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,6 @@ class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
     if (this.container) {
       // plotly.react will not destroy the old plot: https://plot.ly/javascript/plotlyjs-function-reference/#plotlyreact
       this.container = await plotly.react(this.container, data, Object.assign({}, layout), config);
-      this.attachListeners();
     }
   };
 


### PR DESCRIPTION
The listeners are already attached when the plot is first created in the render.
This fixes the exponential growth of the listeners attached to a plot when the plot is re-drawn.
