### PR TITLE
Fix event listener memory leak

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -136,60 +136,79 @@ var PlotlyChart = /** @class */ (function (_super) {
         //   this.container!.on('plotly_buttonclicked', this.props.onButtonClicked);
         // }
         if (this.props.onClick) {
+            this.container.removeAllListeners("plotly_click");
             this.container.on('plotly_click', this.props.onClick);
         }
         if (this.props.onClickAnnotation) {
+            this.container.removeAllListeners("plotly_clickannotation");
             this.container.on('plotly_clickannotation', this.props.onClickAnnotation);
         }
         if (this.props.onDeselect) {
+            this.container.removeAllListeners("plotly_deselect");
             this.container.on('plotly_deselect', this.props.onDeselect);
         }
         if (this.props.onDoubleClick) {
+            this.container.removeAllListeners("plotly_doubleclick");
             this.container.on('plotly_doubleclick', this.props.onDoubleClick);
         }
         if (this.props.onFramework) {
+            this.container.removeAllListeners("plotly_framework");
             this.container.on('plotly_framework', this.props.onFramework);
         }
         if (this.props.onHover) {
+            this.container.removeAllListeners("plotly_hover");
             this.container.on('plotly_hover', this.props.onHover);
         }
         if (this.props.onLegendClick) {
+            this.container.removeAllListeners("plotly_legendclick");
             this.container.on('plotly_legendclick', this.props.onLegendClick);
         }
         if (this.props.onLegendDoubleClick) {
+            this.container.removeAllListeners("plotly_legenddoubleclick");
             this.container.on('plotly_legenddoubleclick', this.props.onLegendDoubleClick);
         }
         if (this.props.onRelayout) {
+            this.container.removeAllListeners("plotly_relayout");
             this.container.on('plotly_relayout', this.props.onRelayout);
         }
         if (this.props.onRestyle) {
+            this.container.removeAllListeners("plotly_restyle");
             this.container.on('plotly_restyle', this.props.onRestyle);
         }
         if (this.props.onRedraw) {
+            this.container.removeAllListeners("plotly_redraw");
             this.container.on('plotly_redraw', this.props.onRedraw);
         }
         if (this.props.onSelecting) {
+            this.container.removeAllListeners("plotly_selecting");
             this.container.on('plotly_selecting', this.props.onSelecting);
         }
         if (this.props.onSliderChange) {
+            this.container.removeAllListeners("plotly_sliderchange");
             this.container.on('plotly_sliderchange', this.props.onSliderChange);
         }
         if (this.props.onSliderEnd) {
+            this.container.removeAllListeners("plotly_sliderend");
             this.container.on('plotly_sliderend', this.props.onSliderEnd);
         }
         if (this.props.onSliderStart) {
+            this.container.removeAllListeners("plotly_sliderstart");
             this.container.on('plotly_sliderstart', this.props.onSliderStart);
         }
         if (this.props.onTransitioning) {
+            this.container.removeAllListeners("plotly_transitioning");
             this.container.on('plotly_transitioning', this.props.onTransitioning);
         }
         if (this.props.onTransitionInterrupted) {
+            this.container.removeAllListeners("plotly_transitioninterrupted");
             this.container.on('plotly_transitioninterrupted', this.props.onTransitionInterrupted);
         }
         if (this.props.onUnHover) {
+            this.container.removeAllListeners("plotly_unhover");
             this.container.on('plotly_unhover', this.props.onUnHover);
         }
         if (this.props.onEvent) {
+            this.container.removeAllListeners("plotly_event");
             this.container.on('plotly_event', this.props.onEvent);
         }
         window.addEventListener('resize', this.resize);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plotlyjs-ts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Typescript-React component for Plotly.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/davidctj/react-plotlyjs-ts.git"
+    "url": "https://github.com/blizzardjessica/react-plotlyjs-ts.git"
   },
   "keywords": [
     "react",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,60 +73,79 @@ class PlotlyChart extends React.Component<IPlotlyChartProps, any> {
     //   this.container!.on('plotly_buttonclicked', this.props.onButtonClicked);
     // }
     if (this.props.onClick) {
+      this.container!.removeAllListeners("plotly_click");
       this.container!.on('plotly_click', this.props.onClick);
     }
     if (this.props.onClickAnnotation) {
+      this.container!.removeAllListeners("plotly_clickannotation");
       this.container!.on('plotly_clickannotation', this.props.onClickAnnotation);
     }
     if (this.props.onDeselect) {
+        this.container!.removeAllListeners("plotly_deselect");
       this.container!.on('plotly_deselect', this.props.onDeselect);
     }
     if (this.props.onDoubleClick) {
+        this.container!.removeAllListeners("plotly_doubleclick");
       this.container!.on('plotly_doubleclick', this.props.onDoubleClick);
     }
     if (this.props.onFramework) {
+        this.container!.removeAllListeners("plotly_framework");
       this.container!.on('plotly_framework', this.props.onFramework);
     }
     if (this.props.onHover) {
+        this.container!.removeAllListeners("plotly_hover");
       this.container!.on('plotly_hover', this.props.onHover);
     }
     if (this.props.onLegendClick) {
+        this.container!.removeAllListeners("plotly_legendclick");
       this.container!.on('plotly_legendclick', this.props.onLegendClick);
     }
     if (this.props.onLegendDoubleClick) {
+        this.container!.removeAllListeners("plotly_legenddoubleclick");
       this.container!.on('plotly_legenddoubleclick', this.props.onLegendDoubleClick);
     }
     if (this.props.onRelayout) {
+        this.container!.removeAllListeners("plotly_relayout");
       this.container!.on('plotly_relayout', this.props.onRelayout);
     }
     if (this.props.onRestyle) {
+        this.container!.removeAllListeners("plotly_restyle");
       this.container!.on('plotly_restyle', this.props.onRestyle);
     }
     if (this.props.onRedraw) {
+        this.container!.removeAllListeners("plotly_redraw");
       this.container!.on('plotly_redraw', this.props.onRedraw);
     }
     if (this.props.onSelecting) {
+        this.container!.removeAllListeners("plotly_selecting");
       this.container!.on('plotly_selecting', this.props.onSelecting);
     }
     if (this.props.onSliderChange) {
+        this.container!.removeAllListeners("plotly_sliderchange");
       this.container!.on('plotly_sliderchange', this.props.onSliderChange);
     }
     if (this.props.onSliderEnd) {
+        this.container!.removeAllListeners("plotly_sliderend");
       this.container!.on('plotly_sliderend', this.props.onSliderEnd);
     }
     if (this.props.onSliderStart) {
+        this.container!.removeAllListeners("plotly_sliderstart");
       this.container!.on('plotly_sliderstart', this.props.onSliderStart);
     }
     if (this.props.onTransitioning) {
+        this.container!.removeAllListeners("plotly_transitioning");
       this.container!.on('plotly_transitioning', this.props.onTransitioning);
     }
     if (this.props.onTransitionInterrupted) {
+        this.container!.removeAllListeners("plotly_transitioninterrupted");
       this.container!.on('plotly_transitioninterrupted', this.props.onTransitionInterrupted);
     }
     if (this.props.onUnHover) {
+        this.container!.removeAllListeners("plotly_unhover");
       this.container!.on('plotly_unhover', this.props.onUnHover);
     }
     if (this.props.onEvent) {
+        this.container!.removeAllListeners("plotly_event");
       this.container!.on('plotly_event', this.props.onEvent);
     }
     window.addEventListener('resize', this.resize);


### PR DESCRIPTION
Event listeners are attached on every draw causing a memory leak.
Fixed by removing event listener from event before attaching.